### PR TITLE
Fixing schedule screen pagers problem

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,11 +33,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true

--- a/app/src/main/java/com/nailorsh/repeton/data/repositories/FakeRepetonRepository.kt
+++ b/app/src/main/java/com/nailorsh/repeton/data/repositories/FakeRepetonRepository.kt
@@ -19,12 +19,12 @@ class FakeRepetonRepository @Inject constructor() : RepetonRepository {
     }
 
     override suspend fun getLessons(): List<Lesson> = withContext(Dispatchers.IO) {
-        delay(2000)
+//        delay(5000)
         FakeLessonSource.loadLessons()
     }
 
     override suspend fun getLessons(day: LocalDate): List<Lesson> = withContext(Dispatchers.IO) {
-        delay(2000)
+//        delay(2000)
         FakeLessonSource.loadLessons().filter {
             it.startTime.year == day.year && it.startTime.dayOfYear == day.dayOfYear
         }

--- a/app/src/main/java/com/nailorsh/repeton/data/repositories/FakeRepetonRepository.kt
+++ b/app/src/main/java/com/nailorsh/repeton/data/repositories/FakeRepetonRepository.kt
@@ -10,6 +10,7 @@ import com.nailorsh.repeton.model.Tutor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import java.time.LocalDate
 import javax.inject.Inject
 
 class FakeRepetonRepository @Inject constructor() : RepetonRepository {
@@ -18,7 +19,15 @@ class FakeRepetonRepository @Inject constructor() : RepetonRepository {
     }
 
     override suspend fun getLessons(): List<Lesson> = withContext(Dispatchers.IO) {
+        delay(2000)
         FakeLessonSource.loadLessons()
+    }
+
+    override suspend fun getLessons(day: LocalDate): List<Lesson> = withContext(Dispatchers.IO) {
+        delay(2000)
+        FakeLessonSource.loadLessons().filter {
+            it.startTime.year == day.year && it.startTime.dayOfYear == day.dayOfYear
+        }
     }
 
     override suspend fun getChats(): List<Chat> = withContext(Dispatchers.IO) {
@@ -29,4 +38,6 @@ class FakeRepetonRepository @Inject constructor() : RepetonRepository {
         delay(2000)
         FakeLessonSource.loadLessons()[id]
     }
+
+
 }

--- a/app/src/main/java/com/nailorsh/repeton/data/sources/FakeLessonSource.kt
+++ b/app/src/main/java/com/nailorsh/repeton/data/sources/FakeLessonSource.kt
@@ -8,8 +8,8 @@ import kotlin.random.Random
 fun getRandomStartDateTime(): LocalDateTime {
 
     return LocalDateTime.now()
-        .plusDays(Random.nextInt(1, 8).toLong())
-        .plusHours(Random.nextInt(0, 24).toLong())
+        .plusDays(Random.nextInt(0, 1).toLong())
+        .plusHours(Random.nextInt(0, 1).toLong())
 }
 
 object FakeLessonSource {
@@ -35,8 +35,8 @@ object FakeLessonSource {
                     title = "Kinematics",
                     description = "Study of motion.",
                     teacherName = "Marie Curie",
-                    startTime = startTime,
-                    endTime = startTime.plusMinutes(90),
+                    startTime = startTime.plusMinutes(90),
+                    endTime = startTime.plusMinutes(180),
                     homeworkLink = null,
                     additionalMaterials = "http://materials.example.com/kinematics"
                 )
@@ -48,8 +48,8 @@ object FakeLessonSource {
                     title = "The French Revolution",
                     description = "A deep dive into the causes of the French Revolution.",
                     teacherName = "Jean Valjean",
-                    startTime = startTime,
-                    endTime = startTime.plusMinutes(90),
+                    startTime = startTime.plusDays(1),
+                    endTime = startTime.plusDays(1).plusMinutes(90),
                     homeworkLink = "http://homework.example.com/french-revolution",
                     additionalMaterials = null
                 )
@@ -61,8 +61,8 @@ object FakeLessonSource {
                     title = "Shakespeare's Plays",
                     description = "Exploring the major plays of William Shakespeare.",
                     teacherName = "Elizabeth Bennett",
-                    startTime = startTime,
-                    endTime = startTime.plusMinutes(90),
+                    startTime = startTime.plusDays(2),
+                    endTime = startTime.plusDays(2).plusMinutes(90),
                     homeworkLink = null,
                     additionalMaterials = "http://materials.example.com/shakespeare"
                 )
@@ -74,8 +74,8 @@ object FakeLessonSource {
                     title = "Introduction to Programming",
                     description = null,
                     teacherName = "Alan Turing",
-                    startTime = startTime,
-                    endTime = startTime.plusMinutes(90),
+                    startTime = startTime.plusDays(2).plusMinutes(90),
+                    endTime = startTime.plusDays(2).plusMinutes(180),
                     homeworkLink = "http://homework.example.com/programming",
                     additionalMaterials = null
                 )
@@ -87,8 +87,8 @@ object FakeLessonSource {
                     title = "Impressionism",
                     description = "Understanding the Impressionist art movement.",
                     teacherName = "Claude Monet",
-                    startTime = startTime,
-                    endTime = startTime.plusMinutes(90),
+                    startTime = startTime.minusDays(1),
+                    endTime = startTime.minusDays(1).plusMinutes(90),
                     homeworkLink = null,
                     additionalMaterials = "http://materials.example.com/impressionism"
                 )

--- a/app/src/main/java/com/nailorsh/repeton/domain/RepetonViewModel.kt
+++ b/app/src/main/java/com/nailorsh/repeton/domain/RepetonViewModel.kt
@@ -1,5 +1,6 @@
 package com.nailorsh.repeton.domain
 
+import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -33,7 +34,7 @@ sealed interface CurrentLessonUiState {
 }
 
 sealed interface ScheduleUiState {
-    data class Success(val lessons: List<Lesson>) : ScheduleUiState
+    data class Success(val lessons: Map<LocalDate, List<Lesson>>) : ScheduleUiState
     object Error : ScheduleUiState
     object Loading : ScheduleUiState
 }
@@ -60,36 +61,46 @@ class RepetonViewModel @Inject constructor(
     var currentLessonUiState: CurrentLessonUiState by mutableStateOf(CurrentLessonUiState.Loading)
         private set
 
+    private var lessonsCache = mutableMapOf<LocalDate, MutableList<Lesson>>()
+
+
     init {
-        getLessons(LocalDate.now())
+        getLessons()
     }
 
     fun getLessons() {
         viewModelScope.launch {
             scheduleUiState = ScheduleUiState.Loading
-            scheduleUiState = try {
-                ScheduleUiState.Success(repetonRepository.getLessons())
-            } catch (e: IOException) {
-                ScheduleUiState.Error
-            } catch (e: HttpRetryException) {
-                ScheduleUiState.Error
+            try {
+                val lessons = repetonRepository.getLessons()
+                lessons.forEach { lesson ->
+                    val day = LocalDate.from(lesson.startTime)
+                    lessonsCache[day] = (lessonsCache[day] ?: mutableListOf()).also {
+                        it.add(lesson)
+                    }
+                }
+                val todayLessons = lessonsCache ?: emptyMap<LocalDate, MutableList<Lesson>>()
+                scheduleUiState = ScheduleUiState.Success(todayLessons)
+            } catch (e: Exception) {
+                scheduleUiState = ScheduleUiState.Error
             }
         }
     }
+//
+//    fun getLessons(day: LocalDate) {
+//        viewModelScope.launch {
+//            scheduleUiState = ScheduleUiState.Loading
+//            scheduleUiState = try {
+//                ScheduleUiState.Success(lessonsCache.getOrDefault(day, listOf()))
+//            } catch (e: IOException) {
+//                ScheduleUiState.Error
+//            } catch (e: HttpRetryException) {
+//                ScheduleUiState.Error
+//            }
+//
+//        }
+//    }
 
-    fun getLessons(day : LocalDate) {
-        viewModelScope.launch {
-            scheduleUiState = ScheduleUiState.Loading
-            scheduleUiState = try {
-                ScheduleUiState.Success(repetonRepository.getLessons(day))
-            } catch (e: IOException) {
-                ScheduleUiState.Error
-            } catch (e: HttpRetryException) {
-                ScheduleUiState.Error
-            }
-
-        }
-    }
 
     fun getLesson(lessonId: Int) {
         viewModelScope.launch {
@@ -104,7 +115,8 @@ class RepetonViewModel @Inject constructor(
             }
         }
     }
-    private  var tutorSearchJob: Job? = null
+
+    private var tutorSearchJob: Job? = null
 
     fun typingTutorSearch(prefix: String) {
         with(prefix) {

--- a/app/src/main/java/com/nailorsh/repeton/domain/RepetonViewModel.kt
+++ b/app/src/main/java/com/nailorsh/repeton/domain/RepetonViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.io.IOException
 import java.net.HttpRetryException
+import java.time.LocalDate
 import javax.inject.Inject
 
 sealed interface SearchUiState {
@@ -60,13 +61,12 @@ class RepetonViewModel @Inject constructor(
         private set
 
     init {
-        getLessons()
+        getLessons(LocalDate.now())
     }
 
     fun getLessons() {
         viewModelScope.launch {
             scheduleUiState = ScheduleUiState.Loading
-            delay(2000)
             scheduleUiState = try {
                 ScheduleUiState.Success(repetonRepository.getLessons())
             } catch (e: IOException) {
@@ -74,6 +74,20 @@ class RepetonViewModel @Inject constructor(
             } catch (e: HttpRetryException) {
                 ScheduleUiState.Error
             }
+        }
+    }
+
+    fun getLessons(day : LocalDate) {
+        viewModelScope.launch {
+            scheduleUiState = ScheduleUiState.Loading
+            scheduleUiState = try {
+                ScheduleUiState.Success(repetonRepository.getLessons(day))
+            } catch (e: IOException) {
+                ScheduleUiState.Error
+            } catch (e: HttpRetryException) {
+                ScheduleUiState.Error
+            }
+
         }
     }
 

--- a/app/src/main/java/com/nailorsh/repeton/domain/repositories/RepetonRepository.kt
+++ b/app/src/main/java/com/nailorsh/repeton/domain/repositories/RepetonRepository.kt
@@ -3,10 +3,12 @@ package com.nailorsh.repeton.domain.repositories
 import com.nailorsh.repeton.model.Chat
 import com.nailorsh.repeton.model.Lesson
 import com.nailorsh.repeton.model.Tutor
+import java.time.LocalDate
 
 interface RepetonRepository {
     suspend fun getTutors(): List<Tutor>
     suspend fun getLessons(): List<Lesson>
+    suspend fun getLessons(day : LocalDate) : List<Lesson>
     suspend fun getChats(): List<Chat>
     suspend fun getLesson(id: Int): Lesson
 }

--- a/app/src/main/java/com/nailorsh/repeton/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/navigation/NavGraph.kt
@@ -60,7 +60,7 @@ fun NavGraph(
             ScheduleScreen(
                 scheduleUiState = repetonViewModel.scheduleUiState,
                 // Вызов getLessons по указанной дате
-                getLessons = { repetonViewModel.getLessons(it) },
+                getLessons = { repetonViewModel.getLessons() },
                 onLessonClicked = { lesson ->
                     navHostController.navigate("lesson/${lesson.id}")
                 }

--- a/app/src/main/java/com/nailorsh/repeton/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/navigation/NavGraph.kt
@@ -14,6 +14,7 @@ import com.nailorsh.repeton.ui.screens.ProfileScreen
 import com.nailorsh.repeton.ui.screens.ScheduleScreen
 import com.nailorsh.repeton.ui.screens.SearchScreen
 import com.nailorsh.repeton.ui.screens.auth.PhoneLoginUI
+import java.time.LocalDate
 
 @Composable
 fun NavGraph(
@@ -55,10 +56,15 @@ fun NavGraph(
             )
         }
         composable(AppSections.HOME.route) {
+
             ScheduleScreen(
+                scheduleUiState = repetonViewModel.scheduleUiState,
+                // Вызов getLessons по указанной дате
+                getLessons = { repetonViewModel.getLessons(it) },
                 onLessonClicked = { lesson ->
                     navHostController.navigate("lesson/${lesson.id}")
                 }
+
             )
         }
         composable(AppSections.CHATS.route) {

--- a/app/src/main/java/com/nailorsh/repeton/ui/screens/ScheduleScreen.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/screens/ScheduleScreen.kt
@@ -92,8 +92,6 @@ fun ScheduleScreen(
 
 
     LaunchedEffect(dayPagerState.currentPage) {
-        Log.v(TAG, dayPagerState.currentPage.toString())
-        Log.v(TAG, selectionSource.toString())
         if (selectionSource == SelectionSource.None) {
             selectionSource = SelectionSource.DayPager
             selectedDay = BASE_DATE.plusDays(dayPagerState.currentPage.toLong())
@@ -104,7 +102,6 @@ fun ScheduleScreen(
     LaunchedEffect(selectedDay) {
 
         getLessons(selectedDay)
-        Log.d(TAG, selectionSource.toString())
         when(selectionSource) {
             SelectionSource.DayPager -> {
                 weekPagerState.animateScrollToPage(ChronoUnit.WEEKS.between(BASE_DATE, selectedDay).toInt())

--- a/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/Calendar.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/Calendar.kt
@@ -1,0 +1,38 @@
+import android.app.DatePickerDialog
+import android.widget.DatePicker
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import java.time.LocalDate
+import java.util.*
+
+@Composable
+fun CalendarDatePicker(
+    selectedDay: LocalDate,
+    selectedDayUpdate: (LocalDate) -> Unit,
+    showDatePickerUpdate: () -> Unit
+) {
+    val context = LocalContext.current
+    val calendar = Calendar.getInstance()
+
+    val datePickerDialog = DatePickerDialog(
+        context,
+        { _: DatePicker, year: Int, month: Int, dayOfMonth: Int ->
+            selectedDayUpdate(LocalDate.of(year, month + 1, dayOfMonth))
+            showDatePickerUpdate()
+        },
+        selectedDay.year,
+        selectedDay.monthValue - 1,
+        selectedDay.dayOfMonth
+    )
+
+
+    // Минимальная дата доступная в календаре
+    calendar.set(2024, Calendar.JANUARY, 1)
+    datePickerDialog.datePicker.minDate = calendar.timeInMillis
+
+    datePickerDialog.setOnDismissListener {
+        showDatePickerUpdate()
+    }
+
+    datePickerDialog.show()
+}

--- a/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/Calendar.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/Calendar.kt
@@ -9,7 +9,8 @@ import java.util.*
 fun CalendarDatePicker(
     selectedDay: LocalDate,
     selectedDayUpdate: (LocalDate) -> Unit,
-    showDatePickerUpdate: () -> Unit
+    showDatePickerUpdate: () -> Unit,
+    changeSelectionSource: () -> Unit
 ) {
     val context = LocalContext.current
     val calendar = Calendar.getInstance()
@@ -17,6 +18,7 @@ fun CalendarDatePicker(
     val datePickerDialog = DatePickerDialog(
         context,
         { _: DatePicker, year: Int, month: Int, dayOfMonth: Int ->
+            changeSelectionSource()
             selectedDayUpdate(LocalDate.of(year, month + 1, dayOfMonth))
             showDatePickerUpdate()
         },

--- a/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/Day.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/Day.kt
@@ -17,12 +17,23 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 
 @Composable
-fun Day(day: LocalDate, selectedDay: LocalDate, onSelectDay: () -> Unit) {
+fun Day(day: LocalDate, selectedDay: LocalDate, hasLessons: Boolean, onSelectDay: () -> Unit) {
     val selected = day.equals(selectedDay)
     val backgroundColor =
-        if (selected) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.tertiaryContainer
+        if (selected)
+            MaterialTheme.colorScheme.tertiary
+        else if (hasLessons)
+            MaterialTheme.colorScheme.tertiaryContainer
+        else MaterialTheme.colorScheme.surfaceContainerHighest
+
     val textColor =
-        if (selected) MaterialTheme.colorScheme.onTertiary else MaterialTheme.colorScheme.onTertiaryContainer
+        if (selected)
+            MaterialTheme.colorScheme.onTertiary
+        else if (hasLessons)
+            MaterialTheme.colorScheme.onTertiaryContainer
+        else MaterialTheme.colorScheme.onSurfaceVariant
+
+
     val numberTextStyle = MaterialTheme.typography.headlineSmall
     val dayTextStyle = MaterialTheme.typography.labelSmall
     val dayFontWeight = FontWeight.W400

--- a/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/Day.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/Day.kt
@@ -1,0 +1,71 @@
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.nailorsh.repeton.R
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+@Composable
+fun Day(day: LocalDate, selectedDay: LocalDate, onSelectDay: () -> Unit) {
+    val selected = day.equals(selectedDay)
+    val backgroundColor =
+        if (selected) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.tertiaryContainer
+    val textColor =
+        if (selected) MaterialTheme.colorScheme.onTertiary else MaterialTheme.colorScheme.onTertiaryContainer
+    val numberTextStyle = MaterialTheme.typography.headlineSmall
+    val dayTextStyle = MaterialTheme.typography.labelSmall
+    val dayFontWeight = FontWeight.W400
+
+    Box(
+        modifier = Modifier
+            .width(36.dp)
+            .height(48.dp)
+            .background(color = backgroundColor, shape = MaterialTheme.shapes.small)
+            .border(width = 1.dp, color = Color.Black, shape = MaterialTheme.shapes.small)
+            .padding(horizontal = 2.dp)
+            .clickable(onClick = onSelectDay)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxHeight()
+                .fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy((-4).dp)
+        ) {
+            Text(
+                text = day.dayOfMonth.toString(),
+                color = textColor,
+                textAlign = TextAlign.Center,
+                style = numberTextStyle,
+                modifier = Modifier.padding(top = 6.dp),
+            )
+            Text(
+                text = when (day.dayOfWeek) {
+                    DayOfWeek.MONDAY -> stringResource(R.string.mon)
+                    DayOfWeek.TUESDAY -> stringResource(R.string.tue)
+                    DayOfWeek.WEDNESDAY -> stringResource(R.string.wed)
+                    DayOfWeek.THURSDAY -> stringResource(R.string.thu)
+                    DayOfWeek.FRIDAY -> stringResource(R.string.fri)
+                    DayOfWeek.SATURDAY -> stringResource(R.string.sat)
+                    DayOfWeek.SUNDAY -> stringResource(R.string.sun)
+                    else -> ""
+                },
+                color = textColor,
+                textAlign = TextAlign.Center,
+                style = dayTextStyle,
+                fontWeight = dayFontWeight
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/DaySlider.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/DaySlider.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import com.nailorsh.repeton.R
+import com.nailorsh.repeton.model.Lesson
 import com.nailorsh.repeton.ui.screens.BASE_DATE
 import com.nailorsh.repeton.ui.screens.MAX_PAGE_COUNT
 import com.nailorsh.repeton.ui.screens.TAG
@@ -27,6 +28,7 @@ fun DaySlider(
     onDaySelected: (LocalDate) -> Unit,
     weekPagerState: PagerState,
     changeSelectionSource: () -> Unit,
+    lessonsMap: Map<LocalDate, List<Lesson>>,
     modifier: Modifier = Modifier
 ) {
 
@@ -49,6 +51,7 @@ fun DaySlider(
                 Day(
                     day = daysOfWeek[index],
                     selectedDay = selectedDay,
+                    hasLessons = lessonsMap[daysOfWeek[index]] != null,
                 ) {
                     changeSelectionSource()
                     onDaySelected(daysOfWeek[index])

--- a/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/DaySlider.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/DaySlider.kt
@@ -1,0 +1,75 @@
+import android.util.Log
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.unit.dp
+import com.nailorsh.repeton.R
+import com.nailorsh.repeton.ui.screens.BASE_DATE
+import com.nailorsh.repeton.ui.screens.Day
+import com.nailorsh.repeton.ui.screens.MAX_PAGE_COUNT
+import com.nailorsh.repeton.ui.screens.TAG
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun DaySlider(
+    selectedDay: LocalDate,
+    onDaySelected: (LocalDate) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Log.v(TAG, selectedDay.toString())
+
+
+    val initialPage = remember { ChronoUnit.WEEKS.between(BASE_DATE, selectedDay).toInt() }
+
+    val pagerState = rememberPagerState(
+        initialPage = initialPage,
+        pageCount = { MAX_PAGE_COUNT }
+    )
+
+    LaunchedEffect(selectedDay) {
+        val newPage = ChronoUnit.WEEKS.between(BASE_DATE, selectedDay).toInt()
+        if (pagerState.currentPage != newPage) {
+            pagerState.animateScrollToPage(newPage)
+        }
+    }
+
+
+
+    HorizontalPager(
+        state = pagerState,
+        pageSpacing = dimensionResource(R.dimen.schedule_screen_days_padding),
+        modifier = modifier
+            .padding(top = 16.dp)
+            .width(dimensionResource(R.dimen.schedule_screen_button_width)),
+    ) { index ->
+        Log.v(TAG, index.toString())
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.schedule_screen_days_padding))
+        ) {
+            val weekStart = BASE_DATE.plusWeeks(index.toLong())
+            val daysOfWeek = List(7) { dayIndex -> weekStart.plusDays(dayIndex.toLong()) }
+
+            items(daysOfWeek.size) { index ->
+                Day(
+                    day = daysOfWeek[index],
+                    selectedDay = selectedDay,
+                ) {
+                    onDaySelected(daysOfWeek[index])
+                }
+            }
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/DaySlider.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/DaySlider.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -14,7 +15,6 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import com.nailorsh.repeton.R
 import com.nailorsh.repeton.ui.screens.BASE_DATE
-import com.nailorsh.repeton.ui.screens.Day
 import com.nailorsh.repeton.ui.screens.MAX_PAGE_COUNT
 import com.nailorsh.repeton.ui.screens.TAG
 import java.time.LocalDate
@@ -25,35 +25,20 @@ import java.time.temporal.ChronoUnit
 fun DaySlider(
     selectedDay: LocalDate,
     onDaySelected: (LocalDate) -> Unit,
+    weekPagerState: PagerState,
+    changeSelectionSource: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Log.v(TAG, selectedDay.toString())
-
-
-    val initialPage = remember { ChronoUnit.WEEKS.between(BASE_DATE, selectedDay).toInt() }
-
-    val pagerState = rememberPagerState(
-        initialPage = initialPage,
-        pageCount = { MAX_PAGE_COUNT }
-    )
-
-    LaunchedEffect(selectedDay) {
-        val newPage = ChronoUnit.WEEKS.between(BASE_DATE, selectedDay).toInt()
-        if (pagerState.currentPage != newPage) {
-            pagerState.animateScrollToPage(newPage)
-        }
-    }
 
 
 
     HorizontalPager(
-        state = pagerState,
+        state = weekPagerState,
         pageSpacing = dimensionResource(R.dimen.schedule_screen_days_padding),
         modifier = modifier
             .padding(top = 16.dp)
             .width(dimensionResource(R.dimen.schedule_screen_button_width)),
     ) { index ->
-        Log.v(TAG, index.toString())
         LazyRow(
             horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.schedule_screen_days_padding))
         ) {
@@ -65,6 +50,7 @@ fun DaySlider(
                     day = daysOfWeek[index],
                     selectedDay = selectedDay,
                 ) {
+                    changeSelectionSource()
                     onDaySelected(daysOfWeek[index])
                 }
             }

--- a/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/LessonBox.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/LessonBox.kt
@@ -1,0 +1,86 @@
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.nailorsh.repeton.R
+import com.nailorsh.repeton.model.Lesson
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+@Composable
+fun LessonBox(lesson: Lesson, onClick: (Lesson) -> Unit, modifier: Modifier = Modifier) {
+
+    Box(
+        modifier = Modifier
+            .padding(top = 21.dp)
+            .width(dimensionResource(R.dimen.schedule_screen_button_width))
+            .height(dimensionResource(R.dimen.schedule_screen_lesson_size))
+            .background(
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                shape = MaterialTheme.shapes.medium
+            )
+            .clickable { onClick(lesson) }
+    )
+    {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 13.dp)
+
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            )
+            {
+                Text(
+                    text = lesson.subject,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    style = MaterialTheme.typography.headlineSmall,
+
+                    )
+
+
+                // Время начала и конца занятия
+                val startTimeCutted =
+                    lesson.startTime.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT))
+                        .substringAfter(", ")
+                val endTimeCutted =
+                    lesson.endTime.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT))
+                        .substringAfter(", ")
+                Text(
+                    text = "$startTimeCutted - $endTimeCutted",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.Medium,
+                    textAlign = TextAlign.Left,
+                    modifier = Modifier
+                        .padding(start = 4.dp)
+                )
+            }
+            Text(
+                text = lesson.teacherName,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                style = MaterialTheme.typography.bodyMedium,
+                letterSpacing = 0.25.sp,
+            )
+            Text(
+                text = lesson.title,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f),
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/LessonCard.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/LessonCard.kt
@@ -1,8 +1,7 @@
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -17,17 +16,20 @@ import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
 @Composable
-fun LessonBox(lesson: Lesson, onClick: (Lesson) -> Unit, modifier: Modifier = Modifier) {
+fun LessonCard(lesson: Lesson, onClick: (Lesson) -> Unit, modifier: Modifier = Modifier) {
 
-    Box(
+    ElevatedCard(
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 4.dp
+        ),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
         modifier = Modifier
-            .padding(top = 21.dp)
+            .padding(top = 10.dp, bottom = 10.dp)
             .width(dimensionResource(R.dimen.schedule_screen_button_width))
             .height(dimensionResource(R.dimen.schedule_screen_lesson_size))
-            .background(
-                color = MaterialTheme.colorScheme.secondaryContainer,
-                shape = MaterialTheme.shapes.medium
-            )
+
             .clickable { onClick(lesson) }
     )
     {

--- a/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/LessonsList.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/LessonsList.kt
@@ -1,0 +1,59 @@
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.nailorsh.repeton.R
+import com.nailorsh.repeton.model.Lesson
+import com.nailorsh.repeton.ui.screens.LessonBox
+
+@Composable
+fun LessonsList(
+    onLessonClicked: (Lesson) -> Unit,
+    lessons: List<Lesson>,
+    modifier: Modifier = Modifier
+) {
+
+
+    Column(
+        modifier = modifier
+    ) {
+        if (lessons.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .padding(top = 21.dp)
+                    .width(dimensionResource(R.dimen.schedule_screen_button_width))
+                    .height(dimensionResource(R.dimen.schedule_screen_lesson_size))
+                    .background(
+                        color = MaterialTheme.colorScheme.secondaryContainer,
+                        shape = MaterialTheme.shapes.medium
+                    )
+            ) {
+                Text(
+                    text = stringResource(R.string.lessons_not_found),
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    style = MaterialTheme.typography.headlineSmall,
+                    modifier = Modifier
+                        .padding(horizontal = 13.dp, vertical = 16.dp)
+                )
+            }
+        } else {
+            LazyColumn {
+                items(lessons.size) {
+                    LessonBox(
+                        lesson = lessons[it],
+                        onClick = onLessonClicked
+                    )
+                }
+
+            }
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/LessonsList.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/LessonsList.kt
@@ -17,7 +17,10 @@ fun LessonsList(
     modifier: Modifier = Modifier
 ) {
 
-
+    Spacer(
+        modifier = Modifier
+            .height(10.dp)
+    )
     Column(
         modifier = modifier
     ) {
@@ -43,7 +46,7 @@ fun LessonsList(
         } else {
             LazyColumn {
                 items(lessons.size) {
-                    LessonBox(
+                    LessonCard(
                         lesson = lessons[it],
                         onClick = onLessonClicked
                     )

--- a/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/LessonsList.kt
+++ b/app/src/main/java/com/nailorsh/repeton/ui/screens/schedule/LessonsList.kt
@@ -10,8 +10,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.nailorsh.repeton.R
 import com.nailorsh.repeton.model.Lesson
-import com.nailorsh.repeton.ui.screens.LessonBox
-
 @Composable
 fun LessonsList(
     onLessonClicked: (Lesson) -> Unit,

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -7,4 +7,5 @@
     <dimen name="divider_thickness">1dp</dimen>
     <dimen name="schedule_screen_button_width">295dp</dimen>
     <dimen name="schedule_screen_lesson_size">95dp</dimen>
+    <dimen name="schedule_screen_days_padding">7dp</dimen>
 </resources>


### PR DESCRIPTION
Исправлена проблема пейджеров. Добавлена переменная для отслеживания источника изменения переменной selectedDay (в зависимости от источника применяются соответствующие эффекты в LaunchedEffect). Изменена логика получения уроков в экране, теперь в экране хранятся уроки не на отдельно взятый день, а на все доступные для того, чтобы улучшить пользовательский опыт от взаимодействия с HorizontalPager. Теперь, если в какой-то из дней есть занятия, то он изменяет свой цвет.